### PR TITLE
Backport new kernel patches com along with hw-mgmt 7.0010.2000

### DIFF
--- a/patch/0024-mlxsw-core-Fix-memory-leak-on-module-removal.patch
+++ b/patch/0024-mlxsw-core-Fix-memory-leak-on-module-removal.patch
@@ -1,0 +1,53 @@
+From f7ef8e5a37f7ae501bce1ae0a5592c4918829e93 Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Mon, 19 Oct 2020 15:30:08 +0300
+Subject: [PATCH] mlxsw: core: Fix memory leak on module removal
+
+Free the devlink instance during the teardown sequence in the non-reload case to avoid the following memory leak.
+
+unreferenced object 0xffff888232895000 (size 2048):
+  comm "modprobe", pid 1073, jiffies 4295568857 (age 164.871s)
+  hex dump (first 32 bytes):
+    00 01 00 00 00 00 ad de 22 01 00 00 00 00 ad de  ........".......
+    10 50 89 32 82 88 ff ff 10 50 89 32 82 88 ff ff  .P.2.....P.2....
+  backtrace:
+    [<00000000c704e9a6>] __kmalloc+0x13a/0x2a0
+    [<00000000ee30129d>] devlink_alloc+0xff/0x760
+    [<0000000092ab3e5d>] 0xffffffffa042e5b0
+    [<000000004f3f8a31>] 0xffffffffa042f6ad
+    [<0000000092800b4b>] 0xffffffffa0491df3
+    [<00000000c4843903>] local_pci_probe+0xcb/0x170
+    [<000000006993ded7>] pci_device_probe+0x2c2/0x4e0
+    [<00000000a8e0de75>] really_probe+0x2c5/0xf90
+    [<00000000d42ba75d>] driver_probe_device+0x1eb/0x340
+    [<00000000bcc95e05>] device_driver_attach+0x294/0x300
+    [<000000000e2bc177>] __driver_attach+0x167/0x2f0
+    [<000000007d44cd6e>] bus_for_each_dev+0x148/0x1f0
+    [<000000003cd5a91e>] driver_attach+0x45/0x60
+    [<000000000041ce51>] bus_add_driver+0x3b8/0x720
+    [<00000000f5215476>] driver_register+0x230/0x4e0
+    [<00000000d79356f5>] __pci_register_driver+0x190/0x200
+
+Fixes: a22712a96291 ("mlxsw: core: Fix devlink unregister flow")
+Signed-off-by: Ido Schimmel <idosch@nvidia.com>
+Reported-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core.c b/drivers/net/ethernet/mellanox/mlxsw/core.c
+index b67d610..e2faedc 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core.c
+@@ -1135,6 +1135,8 @@ void mlxsw_core_bus_device_unregister(struct mlxsw_core *mlxsw_core,
+ 	if (!reload)
+ 		devlink_resources_unregister(devlink, NULL);
+ 	mlxsw_core->bus->fini(mlxsw_core->bus_priv);
++	if (!reload)
++		devlink_free(devlink);
+ 
+ 	return;
+ 
+-- 
+2.8.4
+

--- a/patch/0025-platform-x86-mlx-platform-Remove-PSU-EEPROM-configur.patch
+++ b/patch/0025-platform-x86-mlx-platform-Remove-PSU-EEPROM-configur.patch
@@ -1,0 +1,49 @@
+From 198e605329d5202aec72bf89c291eb7da360dd33 Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Wed, 21 Oct 2020 13:57:35 +0300
+Subject: [PATCH 1/2] platform/x86: mlx-platform: Remove PSU EEPROM
+ configuration
+
+Remove PSU EEPROM configuration for systems class equipped with
+Mellanox chip Spectrum and Celeron CPU. Till now all the systems from this class
+used few types of power units, all equipped with EEPROM device with
+address space two bytes. Thus, all these devices have been handled by
+EEPROM driver "24c02".
+There is a new requirement is to support power unit replacement by "off
+the shelf" device, matching electrical required parameters. Such device
+could be equpped with different EEPROM type, which could be one byte
+address space adressing or even could be not equipped with EEPROM.
+In such case "24c02" will not work.
+
+Fixes: c6acad68e ("platform/mellanox: mlxreg-hotplug: Modify to use a regmap interface")
+Fixes: ba814fdd0 ("platform/x86: mlx-platform: Use defines for bus assignment")
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index d6c87fb..6400f1d 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -375,15 +375,13 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_psu_items_data[] = {
+ 		.label = "psu1",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
+ 		.mask = BIT(0),
+-		.hpdev.brdinfo = &mlxplat_mlxcpld_psu[0],
+-		.hpdev.nr = MLXPLAT_CPLD_PSU_DEFAULT_NR,
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
+ 	},
+ 	{
+ 		.label = "psu2",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
+ 		.mask = BIT(1),
+-		.hpdev.brdinfo = &mlxplat_mlxcpld_psu[1],
+-		.hpdev.nr = MLXPLAT_CPLD_PSU_DEFAULT_NR,
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
+ 	},
+ };
+ 
+-- 
+2.8.4
+

--- a/patch/0026-platform-x86-mlx-platform-Remove-PSU-EEPROM-configur.patch
+++ b/patch/0026-platform-x86-mlx-platform-Remove-PSU-EEPROM-configur.patch
@@ -1,0 +1,48 @@
+From 6a826ae7e734054d610f0d3a9daad88339ee35e7 Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Wed, 21 Oct 2020 15:10:48 +0300
+Subject: [PATCH 2/2] platform/x86: mlx-platform: Remove PSU EEPROM
+ configuration
+
+Remove PSU EEPROM configuration for systems class equipped with
+Mellanox chip Spectrum and Mellanox Broadwell Comex. Till now all the systems from this class
+used few types of power units, all equipped with EEPROM device with
+address space two bytes. Thus, all these devices have been handled by
+EEPROM driver "24c02".
+There is a new requirement is to support power unit replacement by "off
+the shelf" device, matching electrical required parameters. Such device
+could be equpped with different EEPROM type, which could be one byte
+address space adressing or even could be not equipped with EEPROM.
+In such case "24c02" will not work.
+
+Fixes: ef08e14a3 ("platform/x86: mlx-platform: Add support for new msn274x system type")
+Signed-ff-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 6400f1d..c1d1a78 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -593,15 +593,13 @@ static struct mlxreg_core_data mlxplat_mlxcpld_msn274x_psu_items_data[] = {
+ 		.label = "psu1",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
+ 		.mask = BIT(0),
+-		.hpdev.brdinfo = &mlxplat_mlxcpld_psu[0],
+-		.hpdev.nr = MLXPLAT_CPLD_PSU_MSNXXXX_NR,
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
+ 	},
+ 	{
+ 		.label = "psu2",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
+ 		.mask = BIT(1),
+-		.hpdev.brdinfo = &mlxplat_mlxcpld_psu[1],
+-		.hpdev.nr = MLXPLAT_CPLD_PSU_MSNXXXX_NR,
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
+ 	},
+ };
+ 
+-- 
+2.8.4
+

--- a/patch/series
+++ b/patch/series
@@ -74,6 +74,7 @@ driver-ixgbe-external-phy.patch
 0023-mlxsw-core-Add-validation-of-transceiver-temperature.patch
 0024-mlxsw-core-Fix-memory-leak-on-module-removal.patch
 0025-platform-x86-mlx-platform-Remove-PSU-EEPROM-configur.patch
+0026-platform-x86-mlx-platform-Remove-PSU-EEPROM-configur.patch
 ############################################################
 #
 # Internal patches will be added below (placeholder)

--- a/patch/series
+++ b/patch/series
@@ -72,6 +72,7 @@ driver-ixgbe-external-phy.patch
 0021-platform-x86-mlx-platform-Remove-PSU-EEPROM-configur.patch
 0022-mlxsw-core-Increase-critical-threshold-for-ASIC-ther.patch
 0023-mlxsw-core-Add-validation-of-transceiver-temperature.patch
+0024-mlxsw-core-Fix-memory-leak-on-module-removal.patch
 ############################################################
 #
 # Internal patches will be added below (placeholder)

--- a/patch/series
+++ b/patch/series
@@ -73,6 +73,7 @@ driver-ixgbe-external-phy.patch
 0022-mlxsw-core-Increase-critical-threshold-for-ASIC-ther.patch
 0023-mlxsw-core-Add-validation-of-transceiver-temperature.patch
 0024-mlxsw-core-Fix-memory-leak-on-module-removal.patch
+0025-platform-x86-mlx-platform-Remove-PSU-EEPROM-configur.patch
 ############################################################
 #
 # Internal patches will be added below (placeholder)


### PR DESCRIPTION
0024-mlxsw-core-Fix-memory-leak-on-module-removal.patch https://github.com/torvalds/linux/commit/adc80b6cfedff6dad8b93d46a5ea2775fd5af9ec
0025-platform-x86-mlx-platform-Remove-PSU-EEPROM-configur.patch  https://github.com/torvalds/linux/commit/2bf5046bdb649908df8bcc0a012c56eee931a9af
0026-platform-x86-mlx-platform-Remove-PSU-EEPROM-configur.patch  https://github.com/torvalds/linux/commit/912b341585e302ee44fc5a2733f7bcf505e2c86f

Signed-off-by: Kebo Liu <kebol@nvidia.com>