### PR TITLE
[202012]Add config3 register which is using to get COMEX CPU board version

### DIFF
--- a/patch/0153-platform-mellanox-Add-config3-register-support.patch
+++ b/patch/0153-platform-mellanox-Add-config3-register-support.patch
@@ -1,0 +1,56 @@
+From bf9905c1e297307b86d87a809bd42f343bd20cf6 Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Mon, 20 Jun 2022 16:02:14 +0300
+Subject: [PATCH] platform: mellanox: Add config3 register support
+
+Add config3 register which is using to get COMEX CPU board version
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index defa87b44..ee4f8c7c6 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -105,6 +105,7 @@
+ #define MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET 0xf9
+ #define MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET	0xfb
+ #define MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET	0xfc
++#define MLXPLAT_CPLD_LPC_REG_CONFIG3_OFFSET	0xfd
+ #define MLXPLAT_CPLD_LPC_IO_RANGE		0x100
+ #define MLXPLAT_CPLD_LPC_I2C_CH1_OFF		0xdb
+ #define MLXPLAT_CPLD_LPC_I2C_CH2_OFF		0xda
+@@ -1806,6 +1807,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.bit = GENMASK(7, 0),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "config3",
++		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG3_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "ufm_version",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
+@@ -2267,6 +2274,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CONFIG3_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
+ 		return true;
+ 	}
+@@ -2350,6 +2358,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CONFIG3_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
+ 		return true;
+ 	}
+-- 
+2.20.1
+

--- a/patch/series
+++ b/patch/series
@@ -85,6 +85,7 @@ net-sch_generic-fix-the-missing-new-qdisc-assignment.patch
 0032-platform-mellanox-mlxreg-hotplug-Use-capability-regi.patch
 0064-platform-mellanox-mlxreg-io-Fix-read-access-of-n-byt.patch
 0144-platform-x86-mlx-platform-Fix-cpld-_pn-register-seco.patch
+0153-platform-mellanox-Add-config3-register-support.patch
 
 # Cisco patches for 4.19 kernel
 cisco-ds4424-null-of-node.patch


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

Add a new patch come with the hw-mgmt version V.7.0010.2348

`Add config3 register which is using to get COMEX CPU board version`

